### PR TITLE
Added support for layer visibility and cel opacity

### DIFF
--- a/addons/godot_pixelorama_importer/util/read_pxo_file.gd
+++ b/addons/godot_pixelorama_importer/util/read_pxo_file.gd
@@ -36,6 +36,8 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 	var spritesheet = Image.new()
 	spritesheet.create(size.x * frame_count, size.y, false, Image.FORMAT_RGBA8)
 
+	var cel_data_size: int = size.x * size.y * 4
+
 	for i in range(frame_count):
 		var frame = project.frames[i]
 
@@ -43,45 +45,34 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 		var frame_img: Image = null
 		var layer := 0
 		for cel in frame.cels:
-			# Load the cel image
-			var cel_img := Image.new()
-			cel_img.create_from_data(size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(size.x * size.y * 4))
-			
-			if project.layers[layer].visible:
-				var opacity: float = cel.opacity
-				if opacity == 1.0: # Avoid extra gd script calulations:
-					if frame_img == null:
-						frame_img = cel_img
-					else:
-						# Overlay each Cel on top of each other
-						frame_img.blend_rect(cel_img, Rect2(Vector2.ZERO, size), Vector2.ZERO)
-				else: # Blend with cel opacity:
-					if frame_img == null:
-						frame_img = cel_img
-						frame_img.lock()
-						for x in range(size.x):
-							for y in range(size.y):
-								var color := frame_img.get_pixel(x, y)
-								color.a *= opacity
-								frame_img.set_pixel(x, y, color)
-						frame_img.unlock()
-					else:
-						# Overlay each Cel on top of each other with opacity
-						frame_img.lock()
-						cel_img.lock()
-						for x in range(size.x):
-							for y in range(size.y):
-								var frame_col := frame_img.get_pixel(x, y)
-								var cel_col := cel_img.get_pixel(x, y)
-								var a := cel_col.a
-								cel_col.a = 1
-								var color := frame_col.linear_interpolate(cel_col, opacity * a)
-								frame_img.set_pixel(x, y, color)
-						frame_img.unlock()
-						cel_img.unlock()
+			var opacity: float = cel.opacity
+
+			if project.layers[layer].visible and opacity > 0.0:
+				# Load the cel image
+				var cel_img := Image.new()
+				cel_img.create_from_data(size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(cel_data_size))
+
+				if opacity < 1.0:
+					cel_img.lock()
+					for x in range(size.x):
+						for y in range(size.y):
+							var color := cel_img.get_pixel(x, y)
+							color.a *= opacity
+							cel_img.set_pixel(x, y, color)
+					cel_img.unlock()
+
+				if frame_img == null:
+					frame_img = cel_img
+				else:
+					# Overlay each Cel on top of each other
+					frame_img.blend_rect(cel_img, Rect2(Vector2.ZERO, size), Vector2.ZERO)
+			else:
+				# Skip this cel's data
+				file.seek(file.get_position() + cel_data_size)
+
 			layer += 1
 
-		if frame_img:
+		if frame_img != null:
 			# Add to the spritesheet
 			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2((size.x * i), 0))
 

--- a/addons/godot_pixelorama_importer/util/read_pxo_file.gd
+++ b/addons/godot_pixelorama_importer/util/read_pxo_file.gd
@@ -36,24 +36,54 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 	var spritesheet = Image.new()
 	spritesheet.create(size.x * frame_count, size.y, false, Image.FORMAT_RGBA8)
 
-	for i in range(project.frames.size()):
+	for i in range(frame_count):
 		var frame = project.frames[i]
 
 		# Prepare the frame image
 		var frame_img: Image = null
+		var layer := 0
 		for cel in frame.cels:
 			# Load the cel image
-			var cel_img = Image.new()
+			var cel_img := Image.new()
 			cel_img.create_from_data(size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(size.x * size.y * 4))
+			
+			if project.layers[layer].visible:
+				var opacity: float = cel.opacity
+				if opacity == 1.0: # Avoid extra gd script calulations:
+					if frame_img == null:
+						frame_img = cel_img
+					else:
+						# Overlay each Cel on top of each other
+						frame_img.blend_rect(cel_img, Rect2(Vector2.ZERO, size), Vector2.ZERO)
+				else: # Blend with cel opacity:
+					if frame_img == null:
+						frame_img = cel_img
+						frame_img.lock()
+						for x in range(size.x):
+							for y in range(size.y):
+								var color := frame_img.get_pixel(x, y)
+								color.a *= opacity
+								frame_img.set_pixel(x, y, color)
+						frame_img.unlock()
+					else:
+						# Overlay each Cel on top of each other with opacity
+						frame_img.lock()
+						cel_img.lock()
+						for x in range(size.x):
+							for y in range(size.y):
+								var frame_col := frame_img.get_pixel(x, y)
+								var cel_col := cel_img.get_pixel(x, y)
+								var a := cel_col.a
+								cel_col.a = 1
+								var color := frame_col.linear_interpolate(cel_col, opacity * a)
+								frame_img.set_pixel(x, y, color)
+						frame_img.unlock()
+						cel_img.unlock()
+			layer += 1
 
-			if frame_img == null:
-				frame_img = cel_img
-			else:
-				# Overlay each Cel on top of each other
-				frame_img.blend_rect(cel_img, Rect2(Vector2.ZERO, size), Vector2.ZERO)
-
-		# Add to the spritesheet
-		spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2((size.x * i), 0))
+		if frame_img:
+			# Add to the spritesheet
+			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2((size.x * i), 0))
 
 	save_stex(spritesheet, image_save_path)
 	result.value = project


### PR DESCRIPTION
Turning off the visibility of layers in Pixelorama will now result in them being skipped in the plugin.

Adjusting the cel's opacity in Pixelorama will also result in the cels being blended into the frame with a different opacity. Right now it has the old blending code if the opacity is equal to 1 as the opacity code should be slower.

I can create screenshots if needed.