### PR TITLE
Format code and add static checks CI

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,15 @@
+name: Static Checks
+on: [push, pull_request]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdformat --diff .
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdlint .

--- a/addons/godot_pixelorama_importer/plugin.gd
+++ b/addons/godot_pixelorama_importer/plugin.gd
@@ -5,6 +5,7 @@ var editor_settings := get_editor_interface().get_editor_settings()
 
 var import_plugins
 
+
 func handles(object: Object) -> bool:
 	# Find .pxo files
 	if object is Resource && (object as Resource).resource_path.ends_with(".pxo"):
@@ -12,19 +13,21 @@ func handles(object: Object) -> bool:
 
 	return false
 
+
 func edit(object: Object) -> void:
 	# Safeguard
 	if object is Resource && (object as Resource).resource_path.ends_with(".pxo"):
 		if editor_settings.get_setting("pixelorama/path") == "":
 			var popup = AcceptDialog.new()
 			popup.window_title = "No Pixelorama Binary found!"
+			# gdlint: ignore=max-line-length
 			popup.dialog_text = "Specify the path to the binary in the Editor Settings (Editor > Editor Settings...) under Pixelorama > Path"
 			popup.popup_exclusive = true
 			popup.set_as_minsize()
 
 			get_editor_interface().get_base_control().add_child(popup)
 			popup.popup_centered_minsize()
-			
+
 			yield(popup, "confirmed")
 			popup.queue_free()
 			return
@@ -40,12 +43,13 @@ func edit(object: Object) -> void:
 
 		OS.execute(path, [ProjectSettings.globalize_path(object.resource_path)], false)
 
+
 func _enter_tree() -> void:
 	var property_info = {
 		"name": "pixelorama/path",
 		"type": TYPE_STRING,
 	}
-	
+
 	# Set some sane default paths for each OS and their File Selectors
 	match OS.get_name():
 		"Windows":
@@ -70,6 +74,7 @@ func _enter_tree() -> void:
 	]
 	for plugin in import_plugins:
 		add_import_plugin(plugin)
+
 
 func _exit_tree() -> void:
 	for plugin in import_plugins:

--- a/addons/godot_pixelorama_importer/single_image_import.gd
+++ b/addons/godot_pixelorama_importer/single_image_import.gd
@@ -1,32 +1,41 @@
 tool
 extends EditorImportPlugin
 
+
 func get_importer_name():
 	return "com.technohacker.pixelorama"
+
 
 func get_visible_name():
 	return "Single Image"
 
+
 func get_recognized_extensions():
 	return ["pxo"]
+
 
 # We save directly to stex because ImageTexture doesn't work for some reason
 func get_save_extension():
 	return "stex"
 
+
 func get_resource_type():
 	return "StreamTexture"
 
-func get_import_options(preset):
+
+func get_import_options(_preset):
 	return []
 
-func get_option_visibility(option, options):
+
+func get_option_visibility(_option, _options):
 	return true
+
 
 func get_preset_count():
 	return 0
 
-func import(source_file, save_path, options, r_platform_variants, r_gen_files):
+
+func import(source_file, save_path, _options, _r_platform_variants, _r_gen_files):
 	"""
 	Main import function. Reads the Pixelorama project and extracts the PNG image from it
 	"""

--- a/addons/godot_pixelorama_importer/spriteframes_import.gd
+++ b/addons/godot_pixelorama_importer/spriteframes_import.gd
@@ -3,37 +3,45 @@ extends EditorImportPlugin
 
 var editor: EditorInterface
 
+
 func _init(editor_interface):
 	editor = editor_interface
+
 
 func get_importer_name():
 	return "com.technohacker.pixelorama.spriteframe"
 
+
 func get_visible_name():
 	return "SpriteFrames"
 
+
 func get_recognized_extensions():
 	return ["pxo"]
+
 
 # We save directly to stex because ImageTexture doesn't work for some reason
 func get_save_extension():
 	return "tres"
 
+
 func get_resource_type():
 	return "SpriteFrames"
 
-func get_import_options(preset):
-	return [
-		{"name": "animation_fps", "default_value": 6}
-	]
 
-func get_option_visibility(option, options):
+func get_import_options(_preset):
+	return [{"name": "animation_fps", "default_value": 6}]
+
+
+func get_option_visibility(_option, _options):
 	return true
+
 
 func get_preset_count():
 	return 0
 
-func import(source_file, save_path, options, r_platform_variants, r_gen_files):
+
+func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
 	"""
 	Main import function. Reads the Pixelorama project and creates the SpriteFrames resource
 	"""
@@ -63,11 +71,7 @@ func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	var frames = SpriteFrames.new()
 	if project.tags.size() == 0:
 		# No tags, put all in default
-		project.tags.append({
-			"name": "default",
-			"from": 1,
-			"to": project.frames.size()
-		})
+		project.tags.append({"name": "default", "from": 1, "to": project.frames.size()})
 	else:
 		# Has tags, delete the default
 		frames.remove_animation("default")

--- a/addons/godot_pixelorama_importer/util/read_pxo_file.gd
+++ b/addons/godot_pixelorama_importer/util/read_pxo_file.gd
@@ -2,6 +2,7 @@ extends Node
 
 const Result = preload("./Result.gd")
 
+
 static func read_pxo_file(source_file: String, image_save_path: String):
 	var result = Result.new()
 
@@ -20,13 +21,13 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 		result.error = json.error
 		return result
 
-	var project = json.result;
+	var project = json.result
 
 	# Make sure it's a JSON Object
 	if typeof(project) != TYPE_DICTIONARY:
 		printerr("Invalid Pixelorama project file")
-		result.error = ERR_FILE_UNRECOGNIZED;
-		return result;
+		result.error = ERR_FILE_UNRECOGNIZED
+		return result
 
 	# Load the cel dimensions and frame count
 	var size = Vector2(project.size_x, project.size_y)
@@ -50,7 +51,9 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 			if project.layers[layer].visible and opacity > 0.0:
 				# Load the cel image
 				var cel_img := Image.new()
-				cel_img.create_from_data(size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(cel_data_size))
+				cel_img.create_from_data(
+					size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(cel_data_size)
+				)
 
 				if opacity < 1.0:
 					cel_img.lock()
@@ -74,13 +77,14 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 
 		if frame_img != null:
 			# Add to the spritesheet
-			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2((size.x * i), 0))
+			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2(size.x * i, 0))
 
 	save_stex(spritesheet, image_save_path)
 	result.value = project
 	result.error = OK
 
 	return result
+
 
 # Taken from https://github.com/lifelike/godot-animator-import
 static func save_stex(image, save_path):
@@ -95,20 +99,20 @@ static func save_stex(image, save_path):
 
 	var stexf = File.new()
 	stexf.open("%s.stex" % [save_path], File.WRITE)
-	stexf.store_8(0x47) # G
-	stexf.store_8(0x44) # D
-	stexf.store_8(0x53) # S
-	stexf.store_8(0x54) # T
+	stexf.store_8(0x47)  # G
+	stexf.store_8(0x44)  # D
+	stexf.store_8(0x53)  # S
+	stexf.store_8(0x54)  # T
 	stexf.store_32(image.get_width())
 	stexf.store_32(image.get_height())
-	stexf.store_32(0) # flags: Disable all of it as we're dealing with pixel-perfect images
-	stexf.store_32(0x07100000) # data format
-	stexf.store_32(1) # nr mipmaps
+	stexf.store_32(0)  # flags: Disable all of it as we're dealing with pixel-perfect images
+	stexf.store_32(0x07100000)  # data format
+	stexf.store_32(1)  # nr mipmaps
 	stexf.store_32(pnglen + 6)
-	stexf.store_8(0x50) # P
-	stexf.store_8(0x4e) # N
-	stexf.store_8(0x47) # G
-	stexf.store_8(0x20) # space
+	stexf.store_8(0x50)  # P
+	stexf.store_8(0x4e)  # N
+	stexf.store_8(0x47)  # G
+	stexf.store_8(0x20)  # space
 	stexf.store_buffer(pngdata)
 	stexf.close()
 


### PR DESCRIPTION
Run commands `gdformat .` and `gdlint .` from the [godot-gdscript-toolkit](https://github.com/Scony/godot-gdscript-toolkit) to improve the code quality and ensure it follows [GDScript's style guide and best practices](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html). Functionality-wise, nothing should change.

This PR also adds a GitHub Actions workflow that runs these two commands for every commit in this repository. The workflow won't have any effect on the code by itself, it only serves to output errors from the formatter and/or the linter, if there are any.