### PR TITLE
Remove AtlasTexture from SpriteFrames import

### DIFF
--- a/addons/godot_pixelorama_importer/spriteframes_import.gd
+++ b/addons/godot_pixelorama_importer/spriteframes_import.gd
@@ -81,10 +81,12 @@ func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
 		frames.set_animation_speed(tag.name, options.animation_fps)
 
 		for frame in range(tag.from, tag.to + 1):
-			var atlas = AtlasTexture.new()
-			atlas.atlas = spritesheet_tex
-			atlas.region = Rect2(Vector2((frame - 1) * frame_size.x, 0), frame_size)
-			frames.add_frame(tag.name, atlas)
+			var image_rect := Rect2(Vector2((frame - 1) * frame_size.x, 0), frame_size)
+			var image := Image.new()
+			image = spritesheet_tex.get_data().get_rect(image_rect)
+			var image_texture := ImageTexture.new()
+			image_texture.create_from_image(image, 0)
+			frames.add_frame(tag.name, image_texture)
 
 	var err = ResourceSaver.save("%s.%s" % [save_path, get_save_extension()], frames)
 


### PR DESCRIPTION
When importing a pxo as a SpriteFrames resource and then exporting the project, the graphics fail to load completely and instead are invisible. It seems that the cause of the issue is using AtlasTexture to add the frames. This PR changes the code so that it uses Image and ImageTexture instead of AtlasTexture, which seems to be working as expected in exported projects.

I am not sure why AtlasTexture doesn't work, could be a Godot bug?