### PR TITLE
Added Godot Texture Flags

### DIFF
--- a/addons/godot_pixelorama_importer/plugin.gd
+++ b/addons/godot_pixelorama_importer/plugin.gd
@@ -5,7 +5,6 @@ var editor_settings := get_editor_interface().get_editor_settings()
 
 var import_plugins
 
-
 func handles(object: Object) -> bool:
 	# Find .pxo files
 	if object is Resource && (object as Resource).resource_path.ends_with(".pxo"):
@@ -13,21 +12,19 @@ func handles(object: Object) -> bool:
 
 	return false
 
-
 func edit(object: Object) -> void:
 	# Safeguard
 	if object is Resource && (object as Resource).resource_path.ends_with(".pxo"):
 		if editor_settings.get_setting("pixelorama/path") == "":
 			var popup = AcceptDialog.new()
 			popup.window_title = "No Pixelorama Binary found!"
-			# gdlint: ignore=max-line-length
 			popup.dialog_text = "Specify the path to the binary in the Editor Settings (Editor > Editor Settings...) under Pixelorama > Path"
 			popup.popup_exclusive = true
 			popup.set_as_minsize()
 
 			get_editor_interface().get_base_control().add_child(popup)
 			popup.popup_centered_minsize()
-
+			
 			yield(popup, "confirmed")
 			popup.queue_free()
 			return
@@ -43,13 +40,12 @@ func edit(object: Object) -> void:
 
 		OS.execute(path, [ProjectSettings.globalize_path(object.resource_path)], false)
 
-
 func _enter_tree() -> void:
 	var property_info = {
 		"name": "pixelorama/path",
 		"type": TYPE_STRING,
 	}
-
+	
 	# Set some sane default paths for each OS and their File Selectors
 	match OS.get_name():
 		"Windows":
@@ -74,7 +70,6 @@ func _enter_tree() -> void:
 	]
 	for plugin in import_plugins:
 		add_import_plugin(plugin)
-
 
 func _exit_tree() -> void:
 	for plugin in import_plugins:

--- a/addons/godot_pixelorama_importer/single_image_import.gd
+++ b/addons/godot_pixelorama_importer/single_image_import.gd
@@ -2,44 +2,48 @@ tool
 extends EditorImportPlugin
 
 
+const Flags = "DEFAULT:7,MIPMAPS:1,REPEAT:2,MIRRORED_REPEAT:32,FILTER:4,ANISOTROPIC_FILTER:8,CONVERT_TO_LINEAR:16"
+
+
 func get_importer_name():
 	return "com.technohacker.pixelorama"
-
 
 func get_visible_name():
 	return "Single Image"
 
-
 func get_recognized_extensions():
 	return ["pxo"]
-
 
 # We save directly to stex because ImageTexture doesn't work for some reason
 func get_save_extension():
 	return "stex"
 
-
 func get_resource_type():
 	return "StreamTexture"
 
+func get_import_options(preset):
+	return [
+		{"name": "flags/repeat", "default_value": 0, "property_hint" : PROPERTY_HINT_ENUM, "hint_string" : "Disabled:0,Enabled:2,Mirrored:32"},
+		{"name": "flags/filter", "default_value": false},
+		{"name": "flags/mipmaps", "default_value": false},
+		{"name": "flags/anisotropic", "default_value": false},
+	]
 
-func get_import_options(_preset):
-	return []
 
-
-func get_option_visibility(_option, _options):
+func get_option_visibility(option, options):
 	return true
-
 
 func get_preset_count():
 	return 0
 
-
-func import(source_file, save_path, _options, _r_platform_variants, _r_gen_files):
+func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	"""
 	Main import function. Reads the Pixelorama project and extracts the PNG image from it
 	"""
 
 	# Open the project
-	var load_res = preload("./util/read_pxo_file.gd").read_pxo_file(source_file, save_path)
+	var load_res = preload("./util/read_pxo_file.gd").read_pxo_file(source_file, save_path, options)
+	
 	return load_res.error
+	
+	

--- a/addons/godot_pixelorama_importer/spriteframes_import.gd
+++ b/addons/godot_pixelorama_importer/spriteframes_import.gd
@@ -3,45 +3,41 @@ extends EditorImportPlugin
 
 var editor: EditorInterface
 
-
 func _init(editor_interface):
 	editor = editor_interface
-
 
 func get_importer_name():
 	return "com.technohacker.pixelorama.spriteframe"
 
-
 func get_visible_name():
 	return "SpriteFrames"
 
-
 func get_recognized_extensions():
 	return ["pxo"]
-
 
 # We save directly to stex because ImageTexture doesn't work for some reason
 func get_save_extension():
 	return "tres"
 
-
 func get_resource_type():
 	return "SpriteFrames"
 
+func get_import_options(preset):
+	return [
+		{"name": "animation_fps", "default_value": 6},
+		{"name": "flags/repeat", "default_value": 0, "property_hint" : PROPERTY_HINT_ENUM, "hint_string" : "Disabled:0,Enabled:2,Mirrored:32"},
+		{"name": "flags/filter", "default_value": false},
+		{"name": "flags/mipmaps", "default_value": false},
+		{"name": "flags/anisotropic", "default_value": false},
+	]
 
-func get_import_options(_preset):
-	return [{"name": "animation_fps", "default_value": 6}]
-
-
-func get_option_visibility(_option, _options):
+func get_option_visibility(option, options):
 	return true
-
 
 func get_preset_count():
 	return 0
 
-
-func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
+func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	"""
 	Main import function. Reads the Pixelorama project and creates the SpriteFrames resource
 	"""
@@ -49,7 +45,7 @@ func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
 	var spritesheet_path = "%s.spritesheet" % [save_path]
 
 	# Open the project
-	var load_res = preload("./util/read_pxo_file.gd").read_pxo_file(source_file, spritesheet_path)
+	var load_res = preload("./util/read_pxo_file.gd").read_pxo_file(source_file, spritesheet_path, options)
 
 	if load_res.error != OK:
 		printerr("Project Load Error")
@@ -71,7 +67,11 @@ func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
 	var frames = SpriteFrames.new()
 	if project.tags.size() == 0:
 		# No tags, put all in default
-		project.tags.append({"name": "default", "from": 1, "to": project.frames.size()})
+		project.tags.append({
+			"name": "default",
+			"from": 1,
+			"to": project.frames.size()
+		})
 	else:
 		# Has tags, delete the default
 		frames.remove_animation("default")
@@ -81,12 +81,10 @@ func import(source_file, save_path, options, _r_platform_variants, r_gen_files):
 		frames.set_animation_speed(tag.name, options.animation_fps)
 
 		for frame in range(tag.from, tag.to + 1):
-			var image_rect := Rect2(Vector2((frame - 1) * frame_size.x, 0), frame_size)
-			var image := Image.new()
-			image = spritesheet_tex.get_data().get_rect(image_rect)
-			var image_texture := ImageTexture.new()
-			image_texture.create_from_image(image, 0)
-			frames.add_frame(tag.name, image_texture)
+			var atlas = AtlasTexture.new()
+			atlas.atlas = spritesheet_tex
+			atlas.region = Rect2(Vector2((frame - 1) * frame_size.x, 0), frame_size)
+			frames.add_frame(tag.name, atlas)
 
 	var err = ResourceSaver.save("%s.%s" % [save_path, get_save_extension()], frames)
 

--- a/addons/godot_pixelorama_importer/util/read_pxo_file.gd
+++ b/addons/godot_pixelorama_importer/util/read_pxo_file.gd
@@ -2,8 +2,9 @@ extends Node
 
 const Result = preload("./Result.gd")
 
-
-static func read_pxo_file(source_file: String, image_save_path: String):
+# Options is a empty dictionary in case no arguments want to be passes
+static func read_pxo_file(source_file: String, image_save_path: String, options: Dictionary = {}):
+	print(options)
 	var result = Result.new()
 
 	# Open the Pixelorama project file
@@ -21,13 +22,13 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 		result.error = json.error
 		return result
 
-	var project = json.result
+	var project = json.result;
 
 	# Make sure it's a JSON Object
 	if typeof(project) != TYPE_DICTIONARY:
 		printerr("Invalid Pixelorama project file")
-		result.error = ERR_FILE_UNRECOGNIZED
-		return result
+		result.error = ERR_FILE_UNRECOGNIZED;
+		return result;
 
 	# Load the cel dimensions and frame count
 	var size = Vector2(project.size_x, project.size_y)
@@ -51,9 +52,7 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 			if project.layers[layer].visible and opacity > 0.0:
 				# Load the cel image
 				var cel_img := Image.new()
-				cel_img.create_from_data(
-					size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(cel_data_size)
-				)
+				cel_img.create_from_data(size.x, size.y, false, Image.FORMAT_RGBA8, file.get_buffer(cel_data_size))
 
 				if opacity < 1.0:
 					cel_img.lock()
@@ -77,17 +76,16 @@ static func read_pxo_file(source_file: String, image_save_path: String):
 
 		if frame_img != null:
 			# Add to the spritesheet
-			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2(size.x * i, 0))
+			spritesheet.blit_rect(frame_img, Rect2(Vector2.ZERO, size), Vector2((size.x * i), 0))
 
-	save_stex(spritesheet, image_save_path)
+	save_stex(spritesheet, image_save_path, parse_options(options))
 	result.value = project
 	result.error = OK
 
 	return result
 
-
 # Taken from https://github.com/lifelike/godot-animator-import
-static func save_stex(image, save_path):
+static func save_stex(image, save_path, options : Dictionary = {}):
 	var tmppng = "%s-tmp.png" % [save_path]
 	image.save_png(tmppng)
 	var pngf = File.new()
@@ -99,23 +97,44 @@ static func save_stex(image, save_path):
 
 	var stexf = File.new()
 	stexf.open("%s.stex" % [save_path], File.WRITE)
-	stexf.store_8(0x47)  # G
-	stexf.store_8(0x44)  # D
-	stexf.store_8(0x53)  # S
-	stexf.store_8(0x54)  # T
+	stexf.store_8(0x47) # G
+	stexf.store_8(0x44) # D
+	stexf.store_8(0x53) # S
+	stexf.store_8(0x54) # T
 	stexf.store_32(image.get_width())
 	stexf.store_32(image.get_height())
-	stexf.store_32(0)  # flags: Disable all of it as we're dealing with pixel-perfect images
-	stexf.store_32(0x07100000)  # data format
-	stexf.store_32(1)  # nr mipmaps
+	stexf.store_32(options.get("texture_flags", 0)) # flags: Uses the basic Texture.FLAG... Enums
+	stexf.store_32(0x07100000) # data format
+	stexf.store_32(1) # nr mipmaps
 	stexf.store_32(pnglen + 6)
-	stexf.store_8(0x50)  # P
-	stexf.store_8(0x4e)  # N
-	stexf.store_8(0x47)  # G
-	stexf.store_8(0x20)  # space
+	stexf.store_8(0x50) # P
+	stexf.store_8(0x4e) # N
+	stexf.store_8(0x47) # G
+	stexf.store_8(0x20) # space
 	stexf.store_buffer(pngdata)
 	stexf.close()
 
 	print("stex saved")
 
 	return OK
+	
+# Parses options and extracts the flags and makes the final value using the binary operator
+static func parse_options(options : Dictionary) -> Dictionary:
+	var flags = 0
+	
+	match options.get("flags/repeat", 0):
+		Texture.FLAG_REPEAT:
+			flags = flags | Texture.FLAG_REPEAT
+		Texture.FLAG_MIRRORED_REPEAT:
+			flags = flags | Texture.FLAG_MIRRORED_REPEAT
+			
+	if options.get("flags/filter", false):
+		flags = flags | Texture.FLAG_FILTER
+		
+	if options.get("flags/mipmaps", false):
+		flags = flags | Texture.FLAG_MIPMAPS
+		
+	if options.get("flags/filter", false):
+		flags = flags | Texture.FLAG_ANISOTROPIC_FILTER
+	
+	return {"texture_flags": flags}


### PR DESCRIPTION
Exposes options in the godot 'import inspector' to the user to allow for adding Texture.Flags to the .pxo files.

Flags include:
repeat (normal and mirrored)
filter
mipmaps