### PR TITLE
Set update mode for "frame" property to UPDATE_DISCRETE.

### DIFF
--- a/addons/godot_pixelorama_importer/animation_player_import.gd
+++ b/addons/godot_pixelorama_importer/animation_player_import.gd
@@ -169,6 +169,7 @@ func _import(
 		track_index = animation.add_track(Animation.TYPE_VALUE)
 		animation.track_set_path(track_index, ".:frame")
 		animation.track_set_interpolation_loop_wrap(track_index, false)
+		animation.value_track_set_update_mode (track_index, Animation.UPDATE_DISCRETE)
 
 		# insert the new animation keys
 		var time := 0.0


### PR DESCRIPTION
Sets the update mode for "frame" property to UPDATE_DISCRETE. Otherwise there is interpolation from the last frame back to the first. My understanding based on the documentation is that "Clamp loop interpolation" should already prevent this but at least in Godot 4.2.1 it does not:

https://github.com/Technohacker/godot_pixelorama_importer/assets/159484964/b23bf886-23b2-41b2-806a-ddb481ea9912

Whether or not this is a bug in Godot, this works around the problem. I see no drawbacks, since the default update mode UPDATE_CONTINUOUS does not make much sense for frame based animation anyway.